### PR TITLE
Adds a common Base class for all event macro types

### DIFF
--- a/src/constructor/events.nim
+++ b/src/constructor/events.nim
@@ -1,5 +1,7 @@
 import macros
 
+type EventBase* = object of RootObj
+
 macro event*(args: varargs[untyped]): untyped =
   let name = args[0]
   var
@@ -17,7 +19,7 @@ macro event*(args: varargs[untyped]): untyped =
     exportedName = postfix(name, "*") #We always export the event cause we're dumb
 
   result = newStmtList().add quote do:
-    type `exportedName` = object
+    type `exportedName` = object of EventBase
       listeners: seq[`procTy`]
     proc add*(evt: var `name`, newProc: `procTy`) =
       let ind = evt.listeners.find(newProc)


### PR DESCRIPTION
This makes it possible to determine in a macro whether a passed type is
an Event type