### PR TITLE
Added doc comments and runnable examples

### DIFF
--- a/src/constructor/constructor.nim
+++ b/src/constructor/constructor.nim
@@ -1,6 +1,22 @@
 import std/[macros, sets, sugar, strutils]
 
 macro constr*(p: typed): untyped =
+  ## Used as pragma. Automatically creates an instance of the desired type within
+  ## results and populates it with the given parameters of the proc it is used on.
+  ## The parameter names must equal the field names on the instance that is
+  ## being created
+  runnableExamples:
+    import std/options
+
+    type
+      A* = object
+        myInt*: int
+        myOption*: Option[int] 
+        myStr*: string
+
+    proc initA(myInt: int, myOption: Option[int], myStr: string): A {.constr.}
+    assert initA(5, some(2), "hello") == A(myInt: 5, myOption: some(2), myStr: "hello")
+
   result = p.copyNimTree
   let retT = p.params[0]
 

--- a/src/constructor/defaults.nim
+++ b/src/constructor/defaults.nim
@@ -3,6 +3,33 @@ import std/[macros, sugar, macrocache, strutils]
 var defaultTable {.compileTime.} = CacheTable"Constr"
 
 macro defaults*(tdef: untyped, hasRequires: static bool = false): untyped =
+  #Used as pragma. Enables annotating fields on objects with initialization values
+  #When used with a value allocated type, it generates a init<YOUR TYPE> proc.
+  #When used with a heap allocated object, it generates a new<YOUR TYPE> proc. 
+  #The procs are only generated after implDefaults(<YOUR TYPE>) is called.
+  runnableExamples:
+    import std/options
+    type
+      B {.defaults.} = ref object of RootObj
+        myFloat: float = 1.2
+    
+    implDefaults(B)
+
+    type
+      A {.defaults.} = object
+        myInt: int = 5
+        myNoneOption: Option[int] = none(int)
+        mySomeOption: Option[int] = some(6)
+        myStr: string = "lala"
+        myNewB: B = newB()
+
+    implDefaults(A)
+    assert initA().myInt == 5
+    assert initA().myNoneOption == none(int)
+    assert initA().mySomeOption == some(6)
+    assert initA().myStr == "lala"
+    assert initA().myNewB.myFloat == 1.2
+
   result = tdef
   let name = $tdef[0][0].basename
   var

--- a/src/constructor/defaults.nim
+++ b/src/constructor/defaults.nim
@@ -3,10 +3,10 @@ import std/[macros, sugar, macrocache, strutils]
 var defaultTable {.compileTime.} = CacheTable"Constr"
 
 macro defaults*(tdef: untyped, hasRequires: static bool = false): untyped =
-  #Used as pragma. Enables annotating fields on an object type `tdef` with initialization values
-  #When `tdef` is a value allocated type, it generates a init<YOUR TYPE> proc.
-  #When `tdef` is a heap allocated object, it generates a new<YOUR TYPE> proc. 
-  #The procs are only generated after implDefaults(<YOUR TYPE>) is called.
+  ## Used as pragma. Enables annotating fields on an object type `tdef` with initialization values
+  ## When `tdef` is a value allocated type, it generates a init<YOUR TYPE> proc.
+  ## When `tdef` is a heap allocated object, it generates a new<YOUR TYPE> proc. 
+  ## The procs are only generated after implDefaults(<YOUR TYPE>) is called.
   runnableExamples:
     import std/options
     type

--- a/src/constructor/defaults.nim
+++ b/src/constructor/defaults.nim
@@ -3,9 +3,9 @@ import std/[macros, sugar, macrocache, strutils]
 var defaultTable {.compileTime.} = CacheTable"Constr"
 
 macro defaults*(tdef: untyped, hasRequires: static bool = false): untyped =
-  #Used as pragma. Enables annotating fields on objects with initialization values
-  #When used with a value allocated type, it generates a init<YOUR TYPE> proc.
-  #When used with a heap allocated object, it generates a new<YOUR TYPE> proc. 
+  #Used as pragma. Enables annotating fields on an object type `tdef` with initialization values
+  #When `tdef` is a value allocated type, it generates a init<YOUR TYPE> proc.
+  #When `tdef` is a heap allocated object, it generates a new<YOUR TYPE> proc. 
   #The procs are only generated after implDefaults(<YOUR TYPE>) is called.
   runnableExamples:
     import std/options


### PR DESCRIPTION
Essentially this adds 1 runnable example to the "defaults" as well as the "constr" macro.

The example for "constr" could be expanded by an example which follows the `A.init(<some params>)` usage pattern, but I could not get that to compile in any capacity.

Is the "events" file an official feature ? If yes, then I should also add doc comments and runnable examples for that one, I just have no clue neither what it does, nor how it works.